### PR TITLE
Add configurable port to the email server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ lettre_email = "0.9.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
 clap = "2.33.0"
+native-tls = "0.2.4"

--- a/README.md
+++ b/README.md
@@ -53,9 +53,10 @@ people:
       - jules@example.com
 config:
   smtp:
-    address: "stmp.gmail.com:587"
+    address: stmp.gmail.com
     user: email-user@example.com
     password: password
+    port: 587
   email:
     from: email-user@example.com
     subject: Gift for our Lackadaisical party

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ people:
 config:
   smtp:
     address: stmp.gmail.com
+    port: 587
     user: email-user@example.com
     password: password
-    port: 587
   email:
     from: email-user@example.com
     subject: Gift for our Lackadaisical party

--- a/src/email.rs
+++ b/src/email.rs
@@ -1,7 +1,9 @@
 use lettre::smtp::authentication::IntoCredentials;
 use lettre::smtp::ConnectionReuseParameters;
-use lettre::{SmtpClient, Transport};
+use lettre::{ClientSecurity, ClientTlsParameters, SmtpClient, Transport};
+use lettre::smtp::client::net::DEFAULT_TLS_PROTOCOLS;
 use lettre_email::EmailBuilder;
+use native_tls::TlsConnector;
 
 use serde::{Deserialize, Serialize};
 
@@ -12,14 +14,16 @@ pub struct EmailServer {
     address: String,
     user: String,
     password: String,
+    port: u16,
 }
 
 impl EmailServer {
-    pub fn new(address: &str, user: &str, password: &str) -> EmailServer {
+    pub fn new(address: &str, user: &str, password: &str, port: u16) -> EmailServer {
         EmailServer {
             address: address.to_string(),
             user: user.to_string(),
             password: password.to_string(),
+            port
         }
     }
 }
@@ -47,12 +51,21 @@ impl EmailTemplate {
 }
 
 pub fn send_emails(server: &EmailServer, template: &EmailTemplate, pairs: &[pairs::Pair]) {
+    let mut tls_builder = TlsConnector::builder();
+    tls_builder.min_protocol_version(Some(DEFAULT_TLS_PROTOCOLS[0]));
+
+    let tls_parameters =
+        ClientTlsParameters::new(server.address.to_string(), tls_builder.build().unwrap());
+
     let creds = (&server.user, &server.password).into_credentials();
-    let mut mailer = SmtpClient::new_simple(&server.address)
-        .unwrap()
+    let mut mailer = SmtpClient::new(
+        (server.address.to_string(), server.port),
+        ClientSecurity::Opportunistic(tls_parameters),
+    ).unwrap()
         .credentials(creds)
         .connection_reuse(ConnectionReuseParameters::ReuseUnlimited)
         .transport();
+
 
     for pair in pairs.iter() {
         let body = template.format_body(&pair.giver, &pair.receiver);

--- a/src/email.rs
+++ b/src/email.rs
@@ -12,18 +12,18 @@ use pairs;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EmailServer {
     address: String,
+    port: u16,
     user: String,
     password: String,
-    port: u16,
 }
 
 impl EmailServer {
-    pub fn new(address: &str, user: &str, password: &str, port: u16) -> EmailServer {
+    pub fn new(address: &str, port: u16, user: &str, password: &str) -> EmailServer {
         EmailServer {
             address: address.to_string(),
+            port,
             user: user.to_string(),
             password: password.to_string(),
-            port
         }
     }
 }
@@ -65,7 +65,6 @@ pub fn send_emails(server: &EmailServer, template: &EmailTemplate, pairs: &[pair
         .credentials(creds)
         .connection_reuse(ConnectionReuseParameters::ReuseUnlimited)
         .transport();
-
 
     for pair in pairs.iter() {
         let body = template.format_body(&pair.giver, &pair.receiver);

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,7 @@ fn scaffold_config_and_create_file(output_path: &Path) -> io::Result<()> {
             pairs::Person::new("janet@example.com", "Janet", Some(vec!["jules@example.com"])),
         ],
         config::GeneralConfig::new(
-            email::EmailServer::new("stmp.gmail.com", "email-user@example.com", "password", 587),
+            email::EmailServer::new("stmp.gmail.com", 587, "email-user@example.com", "password"),
             email::EmailTemplate::new(
                 "email-user@example.com",
                 "Gift for our Lackadaisical party",

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ extern crate lettre_email;
 extern crate rand;
 extern crate serde;
 extern crate serde_yaml;
+extern crate native_tls;
 
 use std::fs::File;
 use std::io::{self, prelude::*};
@@ -46,7 +47,7 @@ fn scaffold_config_and_create_file(output_path: &Path) -> io::Result<()> {
             pairs::Person::new("janet@example.com", "Janet", Some(vec!["jules@example.com"])),
         ],
         config::GeneralConfig::new(
-            email::EmailServer::new("stmp.gmail.com:587", "email-user@example.com", "password"),
+            email::EmailServer::new("stmp.gmail.com", "email-user@example.com", "password", 587),
             email::EmailTemplate::new(
                 "email-user@example.com",
                 "Gift for our Lackadaisical party",


### PR DESCRIPTION
The current version does not allow us to configure the port and uses the port `587` by default.
Some services such as mailtrap or mailhog use the port 2525 or 1025.

Using the port with the address like this "smtp.mailtrap.io:2525" result in the following error
> thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Io(Custom { kind: Uncategorized, error: "failed to lookup address information: Name or service not known" })', src/email.rs:52:10

To solve this issue I have copied and slightly modified the the source of `SmtpClient::new_simple` and added the port.
Also I choose to use `Opportunistic TLS` instead of the `Required TLS` since local mail catchers such as mailhog doesn't use SSL

- Opportunistic: _Start with insecure connection and use STARTTLS when available_
- Required: _Start with insecure connection and require STARTTLS_